### PR TITLE
fix defect: AttributeError: type object 'ConnectionProxy' has no attribute '_alias'

### DIFF
--- a/django_lock.py
+++ b/django_lock.py
@@ -50,7 +50,7 @@ def _backend_cls(client):
     if DefaultCacheProxy and backend_cls is DefaultCacheProxy:
         cls = settings.CACHES["default"]["BACKEND"]
         backend_cls = import_string(cls)
-    elif ConnectionProxy and backend_cls._alias == DEFAULT_CACHE_ALIAS:
+    elif ConnectionProxy and client._alias == DEFAULT_CACHE_ALIAS:
         cls = settings.CACHES["default"]["BACKEND"]
         backend_cls = import_string(cls)
     return backend_cls


### PR DESCRIPTION
Django==3.2
django-cache-lock=0.2.3

File "/Users/alex/.pyenv/versions/ssm3/lib/python3.7/site-packages/django_lock.py", line 344, in lock
    cls = get_lock_cls(client)
File "/Users/alex/.pyenv/versions/ssm3/lib/python3.7/site-packages/django_lock.py", line 300, in get_lock_cls
    backend_cls = _backend_cls(client)
File "/Users/alex/.pyenv/versions/ssm3/lib/python3.7/site-packages/django_lock.py", line 53, in _backend_cls
    elif ConnectionProxy and backend_cls._alias == DEFAULT_CACHE_ALIAS:
AttributeError: type object 'ConnectionProxy' has no attribute '_alias'